### PR TITLE
Fix display problem on 5.3.x

### DIFF
--- a/app-center-webapps/src/main/webapp/skin/less/customStyle.less
+++ b/app-center-webapps/src/main/webapp/skin/less/customStyle.less
@@ -20,6 +20,9 @@
      color: #a8b3c5!important;
  }
 
+.appCenterDrawer .content .appsContainer.row {
+    padding: 0 12px;
+}
 
 
 


### PR DESCRIPTION
The separator between mandatory applications and not mandatory apps take all the width in 5.3.x.